### PR TITLE
Swapped 'or' operator in blades for PHP's null coalesce operator (??)

### DIFF
--- a/resources/views/alert.blade.php
+++ b/resources/views/alert.blade.php
@@ -1,7 +1,7 @@
 <div
     class="
         alert alert-{{ $type }}
-        {{ $class or '' }}
+        {{ $class ?? '' }}
         @istrue($dismissible, 'alert-dismissible')
         @istrue($animate, 'fade show')
     "

--- a/resources/views/badge.blade.php
+++ b/resources/views/badge.blade.php
@@ -2,7 +2,7 @@
     class="
         badge
         badge-{{ $type }}
-        {{ $class or '' }}
+        {{ $class ?? '' }}
         @istrue($pill, 'badge-pill')
     "
 >

--- a/resources/views/breadcrumb.blade.php
+++ b/resources/views/breadcrumb.blade.php
@@ -1,3 +1,3 @@
-<nav class="breadcrumb {{ $class or '' }}">
+<nav class="breadcrumb {{ $class ?? '' }}">
     {{ $slot }}
 </nav>

--- a/resources/views/button-group.blade.php
+++ b/resources/views/button-group.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="btn-group {{ $class or '' }}"
+    class="btn-group {{ $class ?? '' }}"
     role="group"
 >
     {{ $slot }}

--- a/resources/views/card.blade.php
+++ b/resources/views/card.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="card {{ $class or '' }}"
+    class="card {{ $class ?? '' }}"
 >
     @isset($header)
         <div class="card-header">

--- a/resources/views/carousel.blade.php
+++ b/resources/views/carousel.blade.php
@@ -1,13 +1,13 @@
 <div
-    id="{{ $id or 'carousel' }}"
-    class="carousel slide {{ $class or '' }}"
+    id="{{ $id ?? 'carousel' }}"
+    class="carousel slide {{ $class ?? '' }}"
     data-ride="carousel"
 >
     @istrue($indicators)
         <ol class="carousel-indicators">
             @isset($items)
                 @foreach($items as $item)
-                    <li data-target="#{{ $id or 'carousel' }}" data-slide-to="{{ $loop->index }}"></li>
+                    <li data-target="#{{ $id ?? 'carousel' }}" data-slide-to="{{ $loop->index }}"></li>
                 @endforeach
             @else
                 {!! $indicators !!}
@@ -26,12 +26,12 @@
     </div>
 
     @istrue($controls)
-        <a class="carousel-control-prev" href="#{{ $id or 'carousel' }}" role="button" data-slide="prev">
+        <a class="carousel-control-prev" href="#{{ $id ?? 'carousel' }}" role="button" data-slide="prev">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
             <span class="sr-only">Previous</span>
         </a>
 
-        <a class="carousel-control-next" href="#{{ $id or 'carousel' }}" role="button" data-slide="next">
+        <a class="carousel-control-next" href="#{{ $id ?? 'carousel' }}" role="button" data-slide="next">
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
             <span class="sr-only">Next</span>
         </a>

--- a/resources/views/figure.blade.php
+++ b/resources/views/figure.blade.php
@@ -1,4 +1,4 @@
-<figure class="figure {{ $class or '' }}">
+<figure class="figure {{ $class ?? '' }}">
     {{ $slot }}
 
     @isset($caption)

--- a/resources/views/input-group.blade.php
+++ b/resources/views/input-group.blade.php
@@ -1,3 +1,3 @@
-<div class="input-group {{ $class or '' }}">
+<div class="input-group {{ $class ?? '' }}">
 	{{ $slot }}
 </div>

--- a/resources/views/jumbotron.blade.php
+++ b/resources/views/jumbotron.blade.php
@@ -1,7 +1,7 @@
 <div
     class="
         jumbotron
-        {{ $class or '' }}
+        {{ $class ?? '' }}
         @istrue($fullwidth, 'jumbotron-fluid')
     "
 >

--- a/resources/views/list-group.blade.php
+++ b/resources/views/list-group.blade.php
@@ -1,4 +1,4 @@
-<ul class="list-group {{ $class or '' }}">
+<ul class="list-group {{ $class ?? '' }}">
     @isset($items)
         @foreach($items as $item)
             <li class="list-group-item">{{ $item }}</li>

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -1,6 +1,6 @@
 <div
-    class="modal {{ $animation or 'fade' }} {{ $class or '' }}"
-    id="{{ $id or 'modal' }}"
+    class="modal {{ $animation ?? 'fade' }} {{ $class ?? '' }}"
+    id="{{ $id ?? 'modal' }}"
 >
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -1,5 +1,5 @@
 <nav aria-label="Page navigation">
-    <ul class="pagination {{ $class or '' }}">
+    <ul class="pagination {{ $class ?? '' }}">
         {{ $slot }}
     </ul>
 </nav>

--- a/resources/views/progress.blade.php
+++ b/resources/views/progress.blade.php
@@ -1,11 +1,11 @@
 <div class="progress">
     <div
-        class="progress-bar {{ $class or '' }}"
+        class="progress-bar {{ $class ?? '' }}"
         role="progressbar"
         style="width: {{ $value }}%"
         aria-valuenow="{{ $value }}"
-        aria-valuemin="{{ $min or 0 }}"
-        aria-valuemax="{{ $max or 100 }}"
+        aria-valuemin="{{ $min ?? 0 }}"
+        aria-valuemax="{{ $max ?? 100 }}"
     ></div>
 
     {{ $slot }}

--- a/resources/views/render/pagination.blade.php
+++ b/resources/views/render/pagination.blade.php
@@ -1,9 +1,9 @@
 <nav aria-label="Page navigation">
     @php
-        $paginator = $paginator->toArray();
+        $paginat?? = $paginator->toArray();
     @endphp
 
-    <ul class="pagination {{ $class or '' }}">
+    <ul class="pagination {{ $class ?? '' }}">
         @istrue($arrows)
             <li class="page-item">
                 <a class="page-link" href="{{ $paginator['prev_page_url'] }}" aria-label="Previous">

--- a/resources/views/table.blade.php
+++ b/resources/views/table.blade.php
@@ -1,3 +1,3 @@
-<table class="table table-responsive {{ $class or '' }}">
+<table class="table table-responsive {{ $class ?? '' }}">
     {{ $slot }}
 </table>


### PR DESCRIPTION
Laravel 5.7 has dropped the use of the `or` operator, favouring the use of `PHP`'s `??`.